### PR TITLE
[修复] 网页结构异常导致的评论解析器异常

### DIFF
--- a/app/src/main/java/com/yenaly/han1meviewer/logic/Parser.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/logic/Parser.kt
@@ -695,8 +695,16 @@ object Parser {
         val allCommentsClass = parseBody.getElementById("comment-start")
 
         buildList {
-            allCommentsClass?.children()?.chunked(5)?.forEach { elements ->
-                this += Element("div").apply { appendChildren(elements) }
+            var currentGroup = mutableListOf<Element>()
+            allCommentsClass?.children()?.forEach { element ->
+                currentGroup.add(element)
+                if (element.tagName() == "br") {
+                    this += Element("div").apply { appendChildren(currentGroup) }
+                    currentGroup = mutableListOf()
+                }
+            }
+            if (currentGroup.isNotEmpty()) {
+                this += Element("div").apply { appendChildren(currentGroup) }
             }
         }.forEach { child: Element ->
             val avatarUrl = child.selectFirst("img")?.absUrl("src")


### PR DESCRIPTION
网页结构发生改变，导致原分组逻辑[chunked(5)]不稳定，从而可能发生解析错误。
更新评论解析器逻辑，修复解析异常。